### PR TITLE
add rules field to thread creation and update community handling

### DIFF
--- a/src/Interfaces/ThreadData.ts
+++ b/src/Interfaces/ThreadData.ts
@@ -3,7 +3,7 @@ export interface ThreadData {
 	name: string;
 	description: string;
 	category: string;
-
+	rules: string;
 	created_at?: Date;
 	updated_at?: Date;
 }

--- a/src/Pages/Communities/CreateCommunity.tsx
+++ b/src/Pages/Communities/CreateCommunity.tsx
@@ -14,12 +14,13 @@ const CreateCommunity = ({ isLoggedIn }: CreateCommunityProps) => {
     const [communityName, setCommunityName] = useState("");
     const [category, setCategory] = useState("Stratégia");
     const [description, setDescription] = useState("");
+    const [rules, setRules] = useState("");
 
     const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
 
         setCreating(true);
-        if(!communityName.trim() || !description.trim() || !category.trim()){
+        if(!communityName.trim() || !description.trim() || !category.trim() || !rules.trim()){
             alert("Kérem, töltse ki a kötelező mezőket!");
             setCreating(false);
             return;
@@ -30,6 +31,7 @@ const CreateCommunity = ({ isLoggedIn }: CreateCommunityProps) => {
                 name: communityName.trim(),
                 description: description.trim(),
                 category: category.trim(),
+                rules: rules.trim(),
             });
             setCreated(true);
             navigate("/all-communities");
@@ -91,6 +93,11 @@ const CreateCommunity = ({ isLoggedIn }: CreateCommunityProps) => {
                                         </svg>
                                     </div>
                                 </div>
+                            </div>
+
+                            <div>
+                                <label htmlFor="rules" className="mb-1.5 block text-sm font-medium text-white/90">Szabályok</label>
+                                <textarea id="rules" value={rules} onChange={(e) => setRules(e.target.value)} className="block w-full rounded-xl border border-white/10 bg-white/10 px-4 py-3 text-sm text-white placeholder:text-white/50 outline-none focus:border-white/20" placeholder="Írd be a közösség szabályait"/>
                             </div>
 
                             <div>

--- a/src/Pages/Community/Community.tsx
+++ b/src/Pages/Community/Community.tsx
@@ -1,7 +1,8 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import axios from "axios";
-import httpClient from "../../api/httpClient";
+import { GetPostsInThread, GetThreadById, JoinThread } from "../../api/threads";
+import type { ThreadData } from "../../Interfaces/ThreadData";
 
 interface CommunityProps {
   isLoggedIn: boolean;
@@ -12,6 +13,12 @@ const Community = ({ isLoggedIn }: CommunityProps) => {
   const navigate = useNavigate();
   const [isJoining, setIsJoining] = useState(false);
   const [isJoined, setIsJoined] = useState(false);
+  const [thread, setThread] = useState<ThreadData | null>(null);
+  const [posts, setPosts] = useState<Array<Record<string, unknown>>>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const threadId = id ? Number(id) : NaN;
 
   const handleNewPost = (e: React.MouseEvent<HTMLAnchorElement>) => {
     if (isLoggedIn) return;
@@ -34,9 +41,14 @@ const Community = ({ isLoggedIn }: CommunityProps) => {
       return;
     }
 
+    if (Number.isNaN(threadId)) {
+      alert("Hibás közösség azonosító.");
+      return;
+    }
+
     setIsJoining(true);
     try {
-      await httpClient.post(`/api/threads/${encodeURIComponent(id)}/join`);
+      await JoinThread(threadId);
       setIsJoined(true);
       alert("Sikeresen csatlakoztál!");
     } catch (err) {
@@ -53,6 +65,65 @@ const Community = ({ isLoggedIn }: CommunityProps) => {
     }
   };
 
+  useEffect(() => {
+    if (!id) {
+      setLoadError("Hibás közösség azonosító.");
+      return;
+    }
+
+    if (Number.isNaN(threadId)) {
+      setLoadError("Hibás közösség azonosító.");
+      return;
+    }
+
+    if (!isLoggedIn) {
+      setLoadError("Jelentkezz be a közösség megtekintéséhez.");
+      return;
+    }
+
+    let isCancelled = false;
+    const load = async () => {
+      setIsLoading(true);
+      setLoadError(null);
+      try {
+        const [threadRes, postsRes] = await Promise.all([
+          GetThreadById(threadId),
+          GetPostsInThread(threadId),
+        ]);
+
+        const threadData = (threadRes.data?.thread ?? threadRes.data) as ThreadData;
+        const postsData = (postsRes.data?.posts ?? postsRes.data) as unknown;
+
+        if (!isCancelled) {
+          setThread(threadData);
+          setPosts(Array.isArray(postsData) ? (postsData as Array<Record<string, unknown>>) : []);
+        }
+      } catch (err) {
+        if (isCancelled) return;
+
+        if (axios.isAxiosError(err) && err.response?.status === 401) {
+          navigate("/auth/login", { replace: true });
+          return;
+        }
+
+        const message =
+          axios.isAxiosError(err)
+            ? ((err.response?.data as any)?.message as string | undefined) ?? err.message
+            : err instanceof Error
+              ? err.message
+              : "Nem sikerült betölteni a közösséget.";
+        setLoadError(message);
+      } finally {
+        if (!isCancelled) setIsLoading(false);
+      }
+    };
+
+    void load();
+    return () => {
+      isCancelled = true;
+    };
+  }, [id, isLoggedIn, navigate, threadId]);
+
   return (
     <section className="relative min-h-screen overflow-hidden bg-linear-to-b from-[#35383d] via-[#2b2f34] to-[#1f2226] poppins-regular">
       <div className='absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(59,130,246,0.18),transparent_55%)]' />
@@ -67,8 +138,12 @@ const Community = ({ isLoggedIn }: CommunityProps) => {
                 <div className="h-16 w-16 rounded-2xl bg-white/10 ring-1 ring-white/15" />
                 <div>
                   <div className="text-xs font-semibold uppercase tracking-[0.2em] text-white/60">Community {id ? `#${id}` : ""}</div>
-                  <h1 className="text-3xl font-bold text-white md:text-4xl">Jedlik teszt</h1>
-                  <p className="mt-1 text-sm text-white/70">Akció • 3.2k tag • Aktív</p>
+                  <h1 className="text-3xl font-bold text-white md:text-4xl">
+                    {thread?.name ?? (isLoading ? "Betöltés..." : "Közösség")}
+                  </h1>
+                  <p className="mt-1 text-sm text-white/70">
+                    {thread?.category ? `${thread.category} • ` : ""}Aktív
+                  </p>
                 </div>
               </div>
 
@@ -87,7 +162,9 @@ const Community = ({ isLoggedIn }: CommunityProps) => {
               <div className="rounded-2xl border border-white/10 bg-black/10 p-4">
                 <div className="text-xs font-semibold uppercase tracking-[0.2em] text-white/50">Leírás</div>
                 <div className="mt-2 text-sm text-white/75">
-                    Csatlakozz heti eseményekhez, közös stratégiákhoz és barátságos versenyekhez.
+                    {loadError
+                      ? loadError
+                      : thread?.description ?? (isLoading ? "Betöltés..." : "—")}
                 </div>
               </div>
               <div className="rounded-2xl border border-white/10 bg-black/10 p-4">
@@ -116,21 +193,38 @@ const Community = ({ isLoggedIn }: CommunityProps) => {
                 </Link>
               </div>
               <div className="mt-5 space-y-4">
-                {[1,2,3,4,5].map((n) => (
-                  <article key={n} className="rounded-2xl border border-white/10 bg-black/10 p-5 transition hover:border-white/20">
-                    <div className="flex items-center justify-between text-xs text-white/55">
-                      <span>Admin • 2 órája</span>
-                      <span className="rounded-full bg-white/10 px-3 py-1">Esemény</span>
-                    </div>
-                    <h3 className="mt-3 text-lg font-semibold text-white">Tesztelés</h3>
-                    <p className="mt-2 text-sm text-white/75">sziasztok</p>
-                    <div className="mt-4 flex flex-wrap gap-3">
-                      <button className="rounded-xl border border-white/15 px-4 py-2 text-xs font-semibold text-white/80 transition hover:bg-white/10">Tetszik</button>
-                      <button className="rounded-xl border border-white/15 px-4 py-2 text-xs font-semibold text-white/80 transition hover:bg-white/10">Komment</button>
-                      <button className="rounded-xl border border-white/15 px-4 py-2 text-xs font-semibold text-white/80 transition hover:bg-white/10">Megosztás</button>
-                    </div>
-                  </article>
-                ))}
+                {isLoading && (
+                  <div className="text-sm text-white/70">Posztok betöltése...</div>
+                )}
+
+                {!isLoading && posts.length === 0 && (
+                  <div className="text-sm text-white/70">Nincs még poszt ebben a közösségben.</div>
+                )}
+
+                {posts.map((post, idx) => {
+                  const idValue = (post.id as number | string | undefined) ?? idx;
+                  const title = (post.title as string | undefined) ?? "Poszt";
+                  const content =
+                    (post.content as string | undefined) ??
+                    (post.body as string | undefined) ??
+                    "";
+
+                  return (
+                    <article key={String(idValue)} className="rounded-2xl border border-white/10 bg-black/10 p-5 transition hover:border-white/20">
+                      <div className="flex items-center justify-between text-xs text-white/55">
+                        <span>•</span>
+                        <span className="rounded-full bg-white/10 px-3 py-1">Poszt</span>
+                      </div>
+                      <h3 className="mt-3 text-lg font-semibold text-white">{title}</h3>
+                      <p className="mt-2 whitespace-pre-wrap text-sm text-white/75">{content}</p>
+                      <div className="mt-4 flex flex-wrap gap-3">
+                        <button className="rounded-xl border border-white/15 px-4 py-2 text-xs font-semibold text-white/80 transition hover:bg-white/10">Tetszik</button>
+                        <button className="rounded-xl border border-white/15 px-4 py-2 text-xs font-semibold text-white/80 transition hover:bg-white/10">Komment</button>
+                        <button className="rounded-xl border border-white/15 px-4 py-2 text-xs font-semibold text-white/80 transition hover:bg-white/10">Megosztás</button>
+                      </div>
+                    </article>
+                  );
+                })}
               </div>
             </div>
           </div>

--- a/src/api/threads.ts
+++ b/src/api/threads.ts
@@ -19,6 +19,7 @@ export const CreateThread = async (
 		name: newThread.name,
 		description: newThread.description,
 		category: newThread.category,
+		rules: newThread.rules,
 	});
 
 	return {
@@ -48,7 +49,7 @@ export const JoinThread = async (threadId: number): Promise<ResponseData> => {
 };
 
 export const LeaveThread = async (threadId: number): Promise<ResponseData> => {
-	const response = await httpClient.post(`/api/threads/${threadId}/leave`);
+	const response = await httpClient.delete(`/api/threads/${threadId}/leave`);
 
 	return {
 		status: response.status,
@@ -69,10 +70,11 @@ export const GetPostsInThread = async (
 
 export const CreatePostInThread = async (
 	threadId: number,
-	content: string,
+	post: { title: string; content: string },
 ): Promise<ResponseData> => {
-	const response = await httpClient.post(`/api/threads/${threadId}/posts`, {
-		content,
+	const response = await httpClient.post(`/api/threads/${threadId}/post`, {
+		title: post.title,
+		content: post.content,
 	});
 
 	return {


### PR DESCRIPTION
This pull request introduces significant improvements to the community (thread) feature, focusing on expanding thread metadata, enhancing the community creation process, and improving the experience of viewing and interacting with communities and their posts. The changes ensure that community rules are now part of thread data, streamline API usage, and provide a more dynamic and user-friendly UI for community pages.

**Community metadata and creation:**

- Added a `rules` field to the `ThreadData` interface, and updated the community creation form to require and submit community rules. The backend API and thread creation logic were also updated to handle this new field. [[1]](diffhunk://#diff-a00e8d37e82a730308e771648bdd6e5262da6b2cfa808b0cf4683be57cb63cb5L6-R6) [[2]](diffhunk://#diff-07b2e6830e69bd160419390834eb44eba4ea4b06ccf952e57875040fcbecfcb1R17-R23) [[3]](diffhunk://#diff-07b2e6830e69bd160419390834eb44eba4ea4b06ccf952e57875040fcbecfcb1R34) [[4]](diffhunk://#diff-07b2e6830e69bd160419390834eb44eba4ea4b06ccf952e57875040fcbecfcb1R98-R102) [[5]](diffhunk://#diff-b52a3c1c3ff114a6ac772f05932b3ba5da5625f7baae22db52007a78c51b729aR22)

**Community page improvements:**

- Refactored the `Community` page to fetch real thread and post data using new API functions, display loading states and errors, and render actual posts instead of placeholders. The UI now reflects the actual community name, category, description, and posts, providing a more dynamic and responsive user experience. [[1]](diffhunk://#diff-5e8209ac2cffad6df4c88e0fd0c6dd5b04e2439d33d63b710b9ba1992fe07943L1-R5) [[2]](diffhunk://#diff-5e8209ac2cffad6df4c88e0fd0c6dd5b04e2439d33d63b710b9ba1992fe07943R16-R21) [[3]](diffhunk://#diff-5e8209ac2cffad6df4c88e0fd0c6dd5b04e2439d33d63b710b9ba1992fe07943R44-R51) [[4]](diffhunk://#diff-5e8209ac2cffad6df4c88e0fd0c6dd5b04e2439d33d63b710b9ba1992fe07943R68-R126) [[5]](diffhunk://#diff-5e8209ac2cffad6df4c88e0fd0c6dd5b04e2439d33d63b710b9ba1992fe07943L70-R146) [[6]](diffhunk://#diff-5e8209ac2cffad6df4c88e0fd0c6dd5b04e2439d33d63b710b9ba1992fe07943L90-R167) [[7]](diffhunk://#diff-5e8209ac2cffad6df4c88e0fd0c6dd5b04e2439d33d63b710b9ba1992fe07943L119-R227)

**API adjustments:**

- Updated the `LeaveThread` API to use the HTTP DELETE method instead of POST, aligning with RESTful conventions.
- Modified the post creation API to accept both a `title` and `content`, and changed the endpoint to `/post` for consistency.