### PR TITLE
Resolved: user joined thread synchronization

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import VerifyEmail from "./Pages/Auth/VerifyEmail";
 import CreatePost from "./Pages/Community/CreatePost";
 import LoginPage from "./Pages/Auth/Login";
 import SearchResults from "./Pages/Search/SearchResults";
+import { GetUserThreads } from "./api/users";
 
 function App() {
 	const authTokenName =
@@ -20,6 +21,72 @@ function App() {
 	const [isLoggedIn, setIsLoggedIn] = useState(() =>
 		Boolean(localStorage.getItem(authTokenName)),
 	);
+
+	useEffect(() => {
+		const profileKey = "jedligram_profile";
+
+		const readProfile = (): any => {
+			try {
+				const raw = localStorage.getItem(profileKey);
+				return raw ? JSON.parse(raw) : {};
+			} catch {
+				return {};
+			}
+		};
+
+		const writeProfile = (next: any) => {
+			localStorage.setItem(profileKey, JSON.stringify(next));
+			window.dispatchEvent(new Event("joined-threads-changed"));
+		};
+
+		const syncJoinedThreads = async () => {
+			if (!isLoggedIn) return;
+			const profile = readProfile();
+			const rawId = profile?.userId;
+			const userId =
+				typeof rawId === "number"
+					? rawId
+					: typeof rawId === "string"
+						? Number(rawId)
+						: NaN;
+
+			const resolvedUserId = Number.isFinite(userId) ? userId : undefined;
+			if (!resolvedUserId) return;
+
+			try {
+				const response = await GetUserThreads(resolvedUserId);
+				const raw = response.data;
+				const list =
+					Array.isArray(raw)
+						? raw
+						: Array.isArray((raw as any)?.threads)
+							? (raw as any).threads
+							: Array.isArray((raw as any)?.data)
+								? (raw as any).data
+								: [];
+
+				const joinedThreads = list
+					.filter((t: any) => t && (typeof t.id === "number" || typeof t.id === "string"))
+					.map((t: any) => ({
+						id: Number(t.id),
+						name: typeof t.name === "string" ? t.name : undefined,
+					}))
+					.filter((t: any) => Number.isFinite(t.id));
+
+				const joinedThreadIds = joinedThreads.map((t: any) => t.id);
+				writeProfile({
+					...profile,
+					userId: profile?.userId ?? resolvedUserId,
+					joinedThreads,
+					joinedThreadIds,
+				});
+			} catch {
+				console.warn("Failed to sync joined threads for user", resolvedUserId);
+			}
+		};
+
+		syncJoinedThreads();
+	}, [isLoggedIn]);
 
 	useEffect(() => {
 		const syncAuth = () => {

--- a/src/Pages/Community/Community.tsx
+++ b/src/Pages/Community/Community.tsx
@@ -17,6 +17,11 @@ type RecentThreadItem = {
   name?: string;
 };
 
+type JoinedThreadItem = {
+  id: number;
+  name?: string;
+};
+
 const Community = ({ isLoggedIn }: CommunityProps) => {
   const { id } = useParams<{ id: string }>();
   const location = useLocation();
@@ -49,8 +54,6 @@ const Community = ({ isLoggedIn }: CommunityProps) => {
   const [joinedUsernames, setJoinedUsernames] = useState<string[]>([]);
   const [showAllMembers, setShowAllMembers] = useState(false);
 
-  const [likeCounts, setLikeCounts] = useState<Record<number, number>>({});
-
   const threadId = id ? Number(id) : NaN;
 
   const profileStorageKey = "jedligram_profile";
@@ -67,20 +70,44 @@ const Community = ({ isLoggedIn }: CommunityProps) => {
 
   const updateJoinedThreadsLocal = (threadIdValue: number, threadLabel: string, shouldBeJoined: boolean) => {
     const profile = readProfile();
-    const joinedThreads: string[] = Array.isArray(profile.joinedThreads) ? profile.joinedThreads : [];
-    const joinedThreadIds: number[] = Array.isArray(profile.joinedThreadIds) ? profile.joinedThreadIds : [];
+
+    const joinedThreadIds: number[] = Array.isArray(profile.joinedThreadIds)
+      ? profile.joinedThreadIds.map((x: any) => Number(x)).filter((n: number) => Number.isFinite(n))
+      : [];
+
+    const joinedThreadsRaw = profile.joinedThreads;
+    let joinedThreads: JoinedThreadItem[] = [];
+    if (Array.isArray(joinedThreadsRaw) && joinedThreadsRaw.some((x: any) => x && typeof x === "object" && "id" in x)) {
+      joinedThreads = joinedThreadsRaw
+        .filter((t: any) => t && typeof t === "object" && "id" in t)
+        .map((t: any) => ({
+          id: Number((t as any).id),
+          name: typeof (t as any).name === "string" ? (t as any).name : undefined,
+        }))
+        .filter((t: any) => Number.isFinite(t.id));
+    } else if (Array.isArray(joinedThreadsRaw) && joinedThreadsRaw.every((x: any) => typeof x === "string")) {
+      const names: string[] = joinedThreadsRaw;
+      joinedThreads = joinedThreadIds
+        .map((id, idx) => ({ id, name: names[idx] }))
+        .filter((t) => Number.isFinite(t.id));
+    }
 
     const nextIds = shouldBeJoined
       ? Array.from(new Set([...joinedThreadIds, threadIdValue]))
       : joinedThreadIds.filter((t) => t !== threadIdValue);
 
-    const nextLabels = shouldBeJoined
-      ? Array.from(new Set([...joinedThreads, threadLabel]))
-      : joinedThreads.filter((t) => t !== threadLabel);
+    const nextThreads = shouldBeJoined
+      ? (() => {
+          const exists = joinedThreads.some((t) => t.id === threadIdValue);
+          return exists
+            ? joinedThreads.map((t) => (t.id === threadIdValue ? { ...t, name: t.name ?? threadLabel } : t))
+            : [...joinedThreads, { id: threadIdValue, name: threadLabel }];
+        })()
+      : joinedThreads.filter((t) => t.id !== threadIdValue);
 
     localStorage.setItem(
       profileStorageKey,
-      JSON.stringify({ ...profile, joinedThreads: nextLabels, joinedThreadIds: nextIds }),
+      JSON.stringify({ ...profile, joinedThreads: nextThreads, joinedThreadIds: nextIds }),
     );
 
     window.dispatchEvent(new Event("joined-threads-changed"));
@@ -129,44 +156,19 @@ const Community = ({ isLoggedIn }: CommunityProps) => {
 
   useEffect(() => {
     if (Number.isNaN(threadId)) return;
-    const profile = readProfile();
-    const joinedThreadIds: number[] = Array.isArray(profile.joinedThreadIds) ? profile.joinedThreadIds : [];
-    setIsJoined(joinedThreadIds.includes(threadId));
+
+    const sync = () => {
+      const profile = readProfile();
+      const joinedThreadIds: number[] = Array.isArray(profile.joinedThreadIds)
+        ? profile.joinedThreadIds.map((x: any) => Number(x)).filter((n: number) => Number.isFinite(n))
+        : [];
+      setIsJoined(joinedThreadIds.includes(threadId));
+    };
+
+    sync();
+    window.addEventListener("joined-threads-changed", sync);
+    return () => window.removeEventListener("joined-threads-changed", sync);
   }, [threadId]);
-
-  const syncLikeCountsFromPosts = (postsArray: Array<Record<string, unknown>>) => {
-    setLikeCounts((prev) => {
-      const next = { ...prev };
-
-      for (const post of postsArray) {
-        const postId = parsePostId(post.id);
-        if (Number.isNaN(postId)) continue;
-
-        const serverValue = (post.likes_count as unknown) ?? (post.likesCount as unknown);
-        const serverNumber =
-          typeof serverValue === "number"
-            ? serverValue
-            : typeof serverValue === "string"
-              ? Number(serverValue)
-              : NaN;
-
-        if (Number.isFinite(serverNumber)) {
-          next[postId] = Math.max(0, Math.trunc(serverNumber));
-        } else if (next[postId] === undefined) {
-          next[postId] = 0;
-        }
-      }
-
-      return next;
-    });
-  };
-
-  const getLikeCount = (postId: number, post: Record<string, unknown>): number => {
-    const serverValue = (post.likes_count as unknown) ?? (post.likesCount as unknown);
-    const value = serverValue ?? likeCounts[postId] ?? 0;
-    const n = typeof value === "number" ? value : typeof value === "string" ? Number(value) : 0;
-    return Number.isFinite(n) ? Math.max(0, Math.trunc(n)) : 0;
-  };
 
   const fetchJoinedUsernames = async (threadIdValue: number): Promise<string[]> => {
     if (Number.isNaN(threadIdValue)) return [];
@@ -337,15 +339,6 @@ const Community = ({ isLoggedIn }: CommunityProps) => {
       isCancelled = true;
     };
   }, [id, isLoggedIn, location.key, navigate, threadId]);
-
-  const reloadPosts = async () => {
-    if (Number.isNaN(threadId)) return;
-
-    const postsRes = await GetPostsInThread(threadId);
-    const postsData = (postsRes.data?.posts ?? postsRes.data) as unknown;
-    const postsArray = Array.isArray(postsData) ? (postsData as Array<Record<string, unknown>>) : [];
-    setPosts(postsArray);
-  };
 
   const handleToggleLike = async (postId: number) => {
     if (!isLoggedIn) {

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -9,6 +9,14 @@ const seedProfileFromLoginResponse = (data: any) => {
 	const user = (data as any)?.user ?? (data as any)?.data?.user ?? null;
 	if (!user || typeof user !== "object") return;
 
+	const rawId = (user as any).id ?? (user as any).user_id ?? (user as any).userId;
+	const userId =
+		typeof rawId === "number"
+			? rawId
+			: typeof rawId === "string"
+				? Number(rawId)
+				: NaN;
+
 	const username =
 		typeof (user as any).name === "string" ? (user as any).name : "";
 	const email =
@@ -17,9 +25,11 @@ const seedProfileFromLoginResponse = (data: any) => {
 	localStorage.setItem(
 		"jedligram_profile",
 		JSON.stringify({
+			userId: Number.isFinite(userId) ? userId : undefined,
 			username,
 			email,
 			bio: "",
+			joinedThreads: [],
 			joinedThreadIds: [],
 			profilePictureUrl: "",
 			lastSavedAt: "",


### PR DESCRIPTION
This pull request improves how user "joined threads" are managed and synchronized across the app. The main changes include normalizing the structure of joined thread data in local storage, synchronizing joined threads after login, and updating the `Community` page logic to use the new structure. This should make it easier to reliably track which threads a user has joined and keep the UI in sync.

**Joined Threads Data Model & Synchronization:**

- Normalized the structure of `joinedThreads` in local storage to store an array of objects with `id` and `name` instead of just names or IDs, and ensured `joinedThreadIds` is always an array of numbers. Added logic to sync this data from the server when the user logs in or changes threads. [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R25-R90) [[2]](diffhunk://#diff-5e8209ac2cffad6df4c88e0fd0c6dd5b04e2439d33d63b710b9ba1992fe07943L70-R110) [[3]](diffhunk://#diff-4937285c2d1210b2f5924375f6eab1a4a2f084debdc5034adf1a15595632ae9cR28-R32)

- Added a `useEffect` in `App.tsx` to fetch and synchronize the user's joined threads from the backend after login, updating local storage and dispatching a custom event to notify other components of changes.

**Community Page Refactors:**

- Updated the `Community` page to use the new `JoinedThreadItem` type and normalized joined threads structure, including parsing and updating local storage accordingly when a user joins or leaves a thread. [[1]](diffhunk://#diff-5e8209ac2cffad6df4c88e0fd0c6dd5b04e2439d33d63b710b9ba1992fe07943R20-R24) [[2]](diffhunk://#diff-5e8209ac2cffad6df4c88e0fd0c6dd5b04e2439d33d63b710b9ba1992fe07943L70-R110)

- Refactored the `Community` page's effect for syncing the joined state with local storage, now listening for the `joined-threads-changed` event to update UI reactively when joined threads change elsewhere in the app.

**Profile Initialization:**

- Ensured that when a user logs in, their profile in local storage is seeded with a normalized `userId` and empty arrays for `joinedThreads` and `joinedThreadIds`. [[1]](diffhunk://#diff-4937285c2d1210b2f5924375f6eab1a4a2f084debdc5034adf1a15595632ae9cR12-R19) [[2]](diffhunk://#diff-4937285c2d1210b2f5924375f6eab1a4a2f084debdc5034adf1a15595632ae9cR28-R32)

**Cleanup:**

- Removed unused state and logic related to post like counts and post reloading in the `Community` page, focusing the component on thread membership logic. [[1]](diffhunk://#diff-5e8209ac2cffad6df4c88e0fd0c6dd5b04e2439d33d63b710b9ba1992fe07943L52-L53) [[2]](diffhunk://#diff-5e8209ac2cffad6df4c88e0fd0c6dd5b04e2439d33d63b710b9ba1992fe07943R159-R171) [[3]](diffhunk://#diff-5e8209ac2cffad6df4c88e0fd0c6dd5b04e2439d33d63b710b9ba1992fe07943L341-L349)