### PR TITLE
Add DeletedCommunity page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import CreatePost from "./Pages/Community/CreatePost";
 import LoginPage from "./Pages/Auth/Login";
 import SearchResults from "./Pages/Search/SearchResults";
 import { GetUserThreads } from "./api/users";
+import DeletedCommunity from "./Pages/Community/DeletedCommunity";
 
 function App() {
 	const authTokenName =
@@ -125,6 +126,10 @@ function App() {
 					<Route
 						path="communities/:id"
 						element={<Community isLoggedIn={isLoggedIn} />}
+					/>
+					<Route
+						path="communities/:id/deleted"
+						element={<DeletedCommunity />}
 					/>
 					<Route path="communities/:id/posts/new" element={<CreatePost />} />
 					<Route path="profile" element={<Profile isLoggedIn={isLoggedIn} />} />

--- a/src/Components/Sidebar.tsx
+++ b/src/Components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import DynamicFAIcon from "./Utils/DynamicFaIcon";
 import { PopularIcon } from "./CustomIcons/PopularIcon";
 
@@ -52,6 +52,7 @@ const SidebarCard = ({
 };
 
 const Sidebar = ({ closeSidebar, isSidebarOpen, isLoggedIn }: SidebarProps) => {
+	const navigate = useNavigate();
 	// const [activeCommunity, setActiveCommunity] = useState<number | null>(null);
 	const [joinedThreadIds, setJoinedThreadIds] = useState<JoinedThreadItem[]>(
 		[],
@@ -204,8 +205,14 @@ const Sidebar = ({ closeSidebar, isSidebarOpen, isLoggedIn }: SidebarProps) => {
 											title={t.name ? t.name : `#${t.id}`}
 											icon={`#${t.id}`}
 											to={`/communities/${t.id}`}
-											onClick={() => {
+											onClick={ async () => {
 												closeSidebar();
+												try{
+													const res = await fetch(`/api/threads/${t.id}`);
+        											if (!res.ok) throw new Error("Nem létezik");
+												} catch {
+													navigate(`/deleted-community`);
+												}
 											}}
 										/>
 									))}

--- a/src/Pages/Community/DeletedCommunity.tsx
+++ b/src/Pages/Community/DeletedCommunity.tsx
@@ -1,0 +1,17 @@
+import { Link } from "react-router-dom";
+
+const DeletedCommunity = () => {
+    return (
+        <section className="w-full rounded-3xl border border-white/10 bg-white/5 p-6 text-white shadow-2xl shadow-black/30 backdrop-blur">
+            <h1 className="text-2xl font-black">Ez a közösség már nem elérhető</h1>
+            <p className="mt-2 text-sm text-white/70">
+                Ez a közösség törlésre került, és már nem érhető el. Lehetséges, hogy a közösség tulajdonosa vagy egy adminisztrátor törölte.
+            </p>
+            <Link to="/communities" className="mt-4 inline-block rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700">
+                Vissza a közösségekhez
+            </Link>
+        </section>
+    );
+};
+
+export default DeletedCommunity;


### PR DESCRIPTION
This pull request adds support for handling deleted communities in the app. It introduces a new page to inform users when they attempt to access a community that no longer exists, and updates navigation logic to redirect users appropriately.

**New feature: Handling deleted communities**

* Added a new `DeletedCommunity` page (`src/Pages/Community/DeletedCommunity.tsx`) that displays a message when a community has been deleted and provides a link back to the community list.
* Registered a new route in `App.tsx` for `communities/:id/deleted` to render the `DeletedCommunity` page. [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R17) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R130-R133)

**Sidebar navigation improvements**

* Updated the sidebar navigation logic to check if a community exists before navigating. If the community does not exist, users are redirected to the deleted community page. [[1]](diffhunk://#diff-d06e96412f1936d4f28786fda8f5e45a6ff89439a18131f38f5bdc639a13a06fR55) [[2]](diffhunk://#diff-d06e96412f1936d4f28786fda8f5e45a6ff89439a18131f38f5bdc639a13a06fL207-R215)
* Imported necessary hooks and components (`useNavigate`, `DeletedCommunity`) to support the new navigation and page. [[1]](diffhunk://#diff-d06e96412f1936d4f28786fda8f5e45a6ff89439a18131f38f5bdc639a13a06fL2-R2) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R17)