### PR TITLE
Update CreatePost and PostItem components to remove title input and a…

### DIFF
--- a/src/Pages/Community/CreatePost.tsx
+++ b/src/Pages/Community/CreatePost.tsx
@@ -8,7 +8,6 @@ const CreatePost = () => {
   const navigate = useNavigate();
   const [creating, setCreating] = useState(false);
   const [created, setCreated] = useState(false);
-  const [title, setTitle] = useState("");
   const [content, setContent] = useState("");
 
   const handleSubmit = async () => {
@@ -27,7 +26,7 @@ const CreatePost = () => {
 
     setCreating(true);
     try{
-      await CreatePostInThread(Number(id), { title, content });
+      await CreatePostInThread(Number(id), content, { id: 0, name: "unknown" });
       setCreated(true);
     } catch (err) {
       if (axios.isAxiosError(err)) {
@@ -64,11 +63,6 @@ const CreatePost = () => {
               </button>
             </div>
             <form className="mt-8 grid gap-5" onSubmit={(e) => { e.preventDefault(); handleSubmit(); }}>
-              <div>
-                <label className="text-xs font-semibold uppercase tracking-wider text-white/60">Cím</label>
-                <input type="text" placeholder="Adj egy rövid címet…" className="mt-2 w-full rounded-xl border border-white/10 bg-white/10 px-4 py-3 text-sm text-white placeholder:text-white/50 outline-none focus:border-white/20" value={title} onChange={(e) => setTitle(e.target.value)}/>
-              </div>
-
               <div>
                 <label className="text-xs font-semibold uppercase tracking-wider text-white/60">Tartalom</label>
                 <textarea placeholder="Írd le részletesebben…" className="mt-2 h-44 w-full resize-none rounded-xl border border-white/10 bg-white/10 px-4 py-3 text-sm text-white placeholder:text-white/50 outline-none focus:border-white/20" value={content} onChange={(e) => setContent(e.target.value)}/>

--- a/src/Pages/Community/components/PostItem.tsx
+++ b/src/Pages/Community/components/PostItem.tsx
@@ -12,11 +12,10 @@ type PostItemProps = {
 const PostItem = ({ post, postId, isVoting, score, isCommentsOpen, onToggleComments, onVote, children }: PostItemProps) => (
   <article className="rounded-2xl border border-white/10 bg-black/10 p-5 transition hover:border-white/20">
     <div className="flex items-center justify-between text-xs text-white/55">
-      {post.author ? `@${post.author}` : "Ismeretlen"}
-      <span>{new Date(post.created_at).toLocaleString()}</span>
+      {post.user ? `@${post.user.name}` : "Ismeretlen"}
+      <span>{post.age}</span>
     </div>
-    <h3 className="mt-3 text-lg font-semibold text-white">{post.title || "Poszt"}</h3>
-    <p className="mt-2 whitespace-pre-wrap text-sm text-white/75">{post.content || ""}</p>
+    <h3 className="mt-2 whitespace-pre-wrap text-sm text-white/75">{post.content || ""}</h3>
     <div className="mt-4 flex flex-wrap items-center gap-3">
       <button onClick={() => onToggleComments(postId)} className="cursor-pointer rounded-xl border border-white/15 px-4 py-2 text-xs font-semibold text-white/80 transition hover:bg-white/10">
         {isCommentsOpen ? "Kommentek bezárása" : "Kommentek"}

--- a/src/api/threads.ts
+++ b/src/api/threads.ts
@@ -18,7 +18,6 @@ export const CreateThread = async (
 	const response = await httpClient.post("/api/threads", {
 		name: newThread.name,
 		description: newThread.description,
-		category: newThread.category,
 		rules: newThread.rules,
 	});
 
@@ -70,11 +69,15 @@ export const GetPostsInThread = async (
 
 export const CreatePostInThread = async (
 	threadId: number,
-	post: { title: string; content: string },
+	content: string,
+	user: { id: number; name: string }
 ): Promise<ResponseData> => {
 	const response = await httpClient.post(`/api/threads/${threadId}/post`, {
-		title: post.title,
-		content: post.content,
+		content: content,
+		user: {
+			id: user.id,
+			name: user.name,
+		}
 	});
 
 	return {


### PR DESCRIPTION
…djust post structure
This pull request simplifies the post creation workflow in the community feature by removing the post title field and updating how post data is handled throughout the codebase. It also makes adjustments to the display of post metadata and modifies the API request structure for creating posts.

**Post Creation Workflow Simplification:**

* Removed the `title` field and related state from the `CreatePost` component, so users now only provide post content when creating a post. (`src/Pages/Community/CreatePost.tsx` [[1]](diffhunk://#diff-562cedd27d217bcfa0a92f661538bc94ff5b72e95c9dc161c488fced4c02a90bL11) [[2]](diffhunk://#diff-562cedd27d217bcfa0a92f661538bc94ff5b72e95c9dc161c488fced4c02a90bL67-L71)
* Updated the `CreatePostInThread` API call to accept only `content` and a `user` object, instead of a post object with `title` and `content`. (`src/Pages/Community/CreatePost.tsx` [[1]](diffhunk://#diff-562cedd27d217bcfa0a92f661538bc94ff5b72e95c9dc161c488fced4c02a90bL30-R29) `src/api/threads.ts` [[2]](diffhunk://#diff-b52a3c1c3ff114a6ac772f05932b3ba5da5625f7baae22db52007a78c51b729aL73-R80)

**Post Display Adjustments:**

* Updated the `PostItem` component to remove the display of the post title, show the user's name from the `user` object, and display the post's age instead of the creation date. (`src/Pages/Community/components/PostItem.tsx` [src/Pages/Community/components/PostItem.tsxL15-R18](diffhunk://#diff-5ee73add018709bd9a8dc001a613adac8ad3baa449ffc8ea4d9d66a359274e75L15-R18))

**API Changes:**

* Removed the unused `category` field from the thread creation API call. (`src/api/threads.ts` [src/api/threads.tsL21](diffhunk://#diff-b52a3c1c3ff114a6ac772f05932b3ba5da5625f7baae22db52007a78c51b729aL21))