### PR TITLE
Fix typo in email format error message on Verification page

### DIFF
--- a/src/Pages/Auth/Verification.tsx
+++ b/src/Pages/Auth/Verification.tsx
@@ -29,7 +29,7 @@ export const VerificationPage = () => {
 
 		const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 		if (!emailRegex.test(email)) {
-			setError("Érvénytelen email cím formátum.");
+			setError("Érvénytelen e-mail cím formátum.");
 			button.disabled = false;
 			return;
 		}


### PR DESCRIPTION
This pull request makes a minor update to the error message text for invalid email addresses, correcting the spelling of "e-mail" in the `VerificationPage` component.

- Updated the error message for invalid email format to use the correct spelling "e-mail" instead of "email" in `VerificationPage`.