### PR TITLE
Add Vercel configuration for SPA routing rewrites

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+	"$schema": "https://openapi.vercel.sh/vercel.json",
+	"rewrites": [
+		{
+			"source": "/((?!api/|assets/|.*\\..*).*)",
+			"destination": "/index.html"
+		}
+	]
+}


### PR DESCRIPTION
This pull request introduces a new `vercel.json` configuration file to the project. The main purpose of this change is to set up custom URL rewrites, which will help with client-side routing in a single-page application (SPA) deployed on Vercel.

Vercel deployment configuration:

* Added a `vercel.json` file that defines a rewrite rule: all requests that do not match `/api/`, `/assets/`, or contain a file extension will be redirected to `index.html`. This ensures that client-side routes work correctly in an SPA environment.