### PR TITLE
Add navigation to created community + created post after successful c…

### DIFF
--- a/src/Pages/Communities/CreateCommunity.tsx
+++ b/src/Pages/Communities/CreateCommunity.tsx
@@ -12,6 +12,7 @@ const CreateCommunity = ({ isLoggedIn }: CreateCommunityProps) => {
     const navigate = useNavigate();
     const { t } = useTranslation();
     const [created, setCreated] = useState(false);
+    const [communityId, setCommunityId] = useState<number | null>(null);
     const [communityName, setCommunityName] = useState("");
     const [description, setDescription] = useState("");
     const [rules, setRules] = useState("");
@@ -24,13 +25,14 @@ const CreateCommunity = ({ isLoggedIn }: CreateCommunityProps) => {
             return;
         }
         try{
-            await CreateThread({
+            const response = await CreateThread({
                 id: -1,
                 name: communityName.trim(),
                 description: description.trim(),
                 rules: rules.trim(),
             });
             setCreated(true);
+            setCommunityId(response.data.id);
         } catch(err){
         if(axios.isAxiosError(err)){
             const message = (err.response?.data as any)?.message;
@@ -45,6 +47,12 @@ const CreateCommunity = ({ isLoggedIn }: CreateCommunityProps) => {
             navigate("/auth/login");
         }
     }, [isLoggedIn, navigate]);
+
+    useEffect(() => {
+        if(created){
+            navigate(`/communities/${communityId}`);
+        }
+    })
 
     return (
         <section className="relative min-h-screen overflow-hidden bg-linear-to-b from-[#35383d] via-[#2b2f34] to-[#1f2226] poppins-regular">
@@ -95,15 +103,6 @@ const CreateCommunity = ({ isLoggedIn }: CreateCommunityProps) => {
 
                             <div className="pt-1 text-center text-xs text-white/50">{t('createCommunity.disclaimer')}</div>
                         </form>
-
-                        {created && (
-                            <div className="mt-6 rounded-2xl border border-white/10 bg-black/10 p-4">
-                                <p className="text-sm font-semibold text-emerald-300">{t('createCommunity.success_message')}</p>
-                                <button type="button" onClick={() => navigate("/all-communities")} className="cursor-pointer mt-3 rounded-xl border border-white/15 bg-white/5 px-4 py-2 text-sm font-semibold text-white/80 transition hover:border-white/30 hover:bg-white/10">
-                                    {t('createCommunity.success_button')}
-                                </button>
-                            </div>
-                        )}
                     </div>
                 </div>
             </div>

--- a/src/Pages/Community/CreatePost.tsx
+++ b/src/Pages/Community/CreatePost.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import axios from "axios";
@@ -41,6 +41,12 @@ const CreatePost = () => {
     }
   }
 
+  useEffect(() => {
+    if(created){
+      navigate(`/communities/${encodeURIComponent(id ?? "")}`);
+    }
+  })
+
   return (
     <section className="relative min-h-screen overflow-hidden bg-linear-to-b from-[#35383d] via-[#2b2f34] to-[#1f2226] poppins-regular">
       <div className='absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(59,130,246,0.18),transparent_55%)]' />
@@ -78,15 +84,6 @@ const CreatePost = () => {
                 </button>
               </div>
             </form>
-
-            {created && (
-              <div className="mt-6 rounded-2xl border border-white/10 bg-black/10 p-4">
-                <p className="text-sm font-semibold text-emerald-300">{t('createPost.success_message')}</p>
-                <button type="button" onClick={() => navigate(id ? `/communities/${encodeURIComponent(id)}` : "/all-communities")} className="cursor-pointer mt-3 rounded-xl border border-white/15 bg-white/5 px-4 py-2 text-sm font-semibold text-white/80 transition hover:border-white/30 hover:bg-white/10">
-                  {t('createPost.success_button')}
-                </button>
-              </div>
-            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
This pull request updates the post-creation user flow for both community and post creation pages. Instead of displaying a success message after creating a community or post, users are now automatically redirected to the relevant community page upon successful creation. This streamlines the experience and removes the need for manual navigation after creation.

Redirection and Success Flow Updates:

* Added logic to automatically redirect users to the newly created community page after successfully creating a community, using the returned community ID from the API response (`src/Pages/Communities/CreateCommunity.tsx`). [[1]](diffhunk://#diff-07b2e6830e69bd160419390834eb44eba4ea4b06ccf952e57875040fcbecfcb1R15) [[2]](diffhunk://#diff-07b2e6830e69bd160419390834eb44eba4ea4b06ccf952e57875040fcbecfcb1L27-R35) [[3]](diffhunk://#diff-07b2e6830e69bd160419390834eb44eba4ea4b06ccf952e57875040fcbecfcb1R51-R56)
* Removed the success message and manual navigation button that previously appeared after a community was created, as users are now redirected automatically (`src/Pages/Communities/CreateCommunity.tsx`).
* Implemented similar automatic redirection to the community page after a post is created, and removed the post-creation success message and navigation button (`src/Pages/Community/CreatePost.tsx`). [[1]](diffhunk://#diff-562cedd27d217bcfa0a92f661538bc94ff5b72e95c9dc161c488fced4c02a90bR44-R49) [[2]](diffhunk://#diff-562cedd27d217bcfa0a92f661538bc94ff5b72e95c9dc161c488fced4c02a90bL81-L89)
* Added necessary imports for `useEffect` to support the new redirection logic (`src/Pages/Community/CreatePost.tsx`).