### PR TITLE
integrate CommunityCardItem component for better structure and readability

### DIFF
--- a/src/Components/Communities.tsx
+++ b/src/Components/Communities.tsx
@@ -3,13 +3,13 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { GetThreads } from "../api/threads";
 import type { ThreadData } from "../Interfaces/ThreadData";
+import CommunityCardItem from "./CommunityCard/CommunityCardItem";
 
 const Communities = () => {
 	const { t } = useTranslation();
 	const [threads, setThreads] = useState<ThreadData[]>([]);
 	const [isLoading, setIsLoading] = useState(true);
 	const [loadError, setLoadError] = useState<string | null>(null);
-	const [reloadToken, setReloadToken] = useState(0);
 
 	useEffect(() => {
 		const fetchThreads = async () => {
@@ -27,7 +27,7 @@ const Communities = () => {
 			}
 		};
 		fetchThreads();
-	}, [reloadToken]);
+	}, [t]);
 
 	const visibleThreads = threads.slice(0, 6);
 
@@ -55,15 +55,6 @@ const Communities = () => {
 						<Link to="/create-community" className="text-center rounded-2xl bg-linear-to-r from-blue-500 to-indigo-500 px-6 py-3 text-sm font-semibold text-white keep-white shadow-lg shadow-blue-500/30 transition hover:-translate-y-0.5 hover:shadow-blue-500/50">{t('communities.create')}</Link>
 					</div>
 				</div>
-
-				{loadError && (
-					<div className="rounded-3xl border border-red-400/20 bg-red-500/10 p-5 text-white/80">
-						<div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-							<p className="text-sm font-semibold text-red-200">{loadError}</p>
-							<button onClick={() => setReloadToken(t => t + 1)} className="rounded-2xl border border-white/15 bg-white/5 px-5 py-2 text-sm font-semibold text-white/80 transition hover:border-white/30 hover:bg-white/10">{t('communities.retry')}</button>
-						</div>
-					</div>
-				)}
 
 				<div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
 
@@ -95,20 +86,7 @@ const Communities = () => {
 
 					{!isLoading && !loadError && visibleThreads.map(thread => {
 						return (
-							<div key={thread.id} className="group relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 p-6 shadow-xl shadow-black/30 backdrop-blur transition hover:-translate-y-1 hover:border-white/20">
-								<div className="absolute inset-0 bg-linear-to-br from-cyan-400/30 to-blue-500/2 opacity-0 transition duration-500 group-hover:opacity-100"/>
-								<div className="relative z-10 flex h-full flex-col gap-4">
-									<div className="flex items-center justify-between text-xs font-semibold uppercase tracking-[0.2em] text-white/50">
-										<span className="rounded-full bg-white/10 px-3 py-1 text-[10px]">{t('communities.active')}</span>
-									</div>
-									<h3 className="text-2xl font-semibold text-white">{thread.name}</h3>
-									<p className="text-sm text-white/70">{thread.description || t('communities.default_description')}</p>
-									<div className="mt-auto flex items-center justify-between">
-										<span className="text-sm font-semibold text-white/80">{thread.users_count} {t('communities.members')}</span>
-										<Link to={`/communities/${thread.id}`} className="rounded-full border border-white/20 px-4 py-2 text-xs font-semibold text-white transition hover:border-white/40 hover:bg-white/10">{t('communities.view_community')}</Link>
-									</div>
-								</div>
-							</div>
+							<CommunityCardItem key={thread.id} threads={[thread]} />
 						);
 					})}
 

--- a/src/Components/CommunityCard/CommunityCardItem.tsx
+++ b/src/Components/CommunityCard/CommunityCardItem.tsx
@@ -1,0 +1,38 @@
+import { Link } from "react-router-dom"
+import type { ThreadData } from "../../Interfaces/ThreadData"
+import { useTranslation } from "react-i18next";
+
+const CommunityCardItem = ({ threads }: { threads: ThreadData[] }) => {
+  const { t } = useTranslation();
+
+  return (
+    <Link to={`/communities/${threads[0]?.id}`} className="group relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 p-6 shadow-xl shadow-black/30 backdrop-blur transition hover:-translate-y-1 hover:border-white/20">
+        <div className={`absolute inset-0 bg-linear-to-br opacity-0 transition duration-500 group-hover:opacity-100`}/>
+        <div className="relative z-10 flex h-full flex-col gap-4">
+            <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-[0.2em] text-white/50">
+                <span className="px-2 py-1 rounded-full border border-white/20 bg-white/10 text-xs font-semibold text-white/80">{threads[0]?.users_count ?? "N/A"} {t('allCommunities.members')}</span>
+            </div>
+            <div className="flex items-start gap-4">
+                <div className="shrink-0 flex h-16 w-16 items-center justify-center rounded-2xl bg-white/10 ring-1 ring-white/15">
+                    <span className="text-2xl font-bold text-white/60">{threads[0]?.name.charAt(0).toUpperCase()}</span>
+                </div>
+                <div className="flex-1">
+                    <h3 className="text-2xl font-semibold text-white">
+                        {threads[0]?.name}
+                    </h3>
+                    <p className="text-sm text-white/70">
+                        {threads[0]?.description || t('allCommunities.default_description')}
+                    </p>
+                </div>
+            </div>
+            <div className="mt-auto flex items-center justify-end">
+                <Link to={`/communities/${threads[0]?.id}`} className="rounded-full border border-white/20 px-4 py-2 text-xs font-semibold text-white transition hover:border-white/40 hover:bg-white/10">
+                    {t('allCommunities.view_button')}
+                </Link>
+            </div>
+        </div>
+    </Link>
+  )
+}
+
+export default CommunityCardItem

--- a/src/Pages/Communities/AllCommunities.tsx
+++ b/src/Pages/Communities/AllCommunities.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import type { ThreadData } from "../../Interfaces/ThreadData";
 import { GetThreads } from "../../api/threads";
 import WelcomeBanner from "../../Components/Utils/WelcomeBanner";
+import CommunityCardItem from "../../Components/CommunityCard/CommunityCardItem";
 
 interface AllCommunityProps{
 	isLoggedIn: boolean;
@@ -71,36 +72,9 @@ const AllCommunities = ({ isLoggedIn }: AllCommunityProps) => {
             <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
                 {threads.map((thread) => {
 					return (
-                    <div key={thread.id} className="group relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 p-6 shadow-xl shadow-black/30 backdrop-blur transition hover:-translate-y-1 hover:border-white/20">
-                        <div className={`absolute inset-0 bg-linear-to-br opacity-0 transition duration-500 group-hover:opacity-100`}/>
-                        <div className="relative z-10 flex h-full flex-col gap-4">
-                            <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-[0.2em] text-white/50">
-                                <span className="px-2 py-1 rounded-full border border-white/20 bg-white/10 text-xs font-semibold text-white/80">{thread.users_count ?? "N/A"} {t('allCommunities.members')}</span>
-                            </div>
-                            <div className="flex items-start gap-4">
-                                <div className="shrink-0 flex h-16 w-16 items-center justify-center rounded-2xl bg-white/10 ring-1 ring-white/15">
-                                    <span className="text-2xl font-bold text-white/60">{thread.name.charAt(0).toUpperCase()}</span>
-                                </div>
-                                <div className="flex-1">
-                                    <h3 className="text-2xl font-semibold text-white">
-                                        {thread.name}
-                                    </h3>
-                                    <p className="text-sm text-white/70">
-                                        {thread.description || t('allCommunities.default_description')}
-                                    </p>
-                                </div>
-                            </div>
-                            <div className="mt-auto flex items-center justify-between">
-                                <span className="text-sm font-semibold text-white/80">
-                                    {/* {thread.members} */}
-                                </span>
-                                <Link to={`/communities/${thread.id}`} className="rounded-full border border-white/20 px-4 py-2 text-xs font-semibold text-white transition hover:border-white/40 hover:bg-white/10">
-                                    {t('allCommunities.view_button')}
-                                </Link>
-                            </div>
-                        </div>
-                    </div>
-                )})}
+                        <CommunityCardItem key={thread.id} threads={[thread]} />
+                    )
+                })}
             </div>
         </div>
     </section>


### PR DESCRIPTION
This pull request refactors the way community cards are rendered in both the `Communities` and `AllCommunities` components by introducing a new reusable `CommunityCardItem` component. It also removes the error handling and reload logic from the `Communities` component, simplifying its state management. The main focus is on improving code reuse and maintainability by centralizing the card UI.

Component refactoring and code reuse:

* Introduced a new `CommunityCardItem` component in `src/Components/CommunityCard/CommunityCardItem.tsx` to encapsulate the community card UI, making it reusable across different parts of the app.
* Updated both `Communities` (`src/Components/Communities.tsx`) and `AllCommunities` (`src/Pages/Communities/AllCommunities.tsx`) components to use the new `CommunityCardItem` for rendering community cards, replacing duplicated inline JSX. [[1]](diffhunk://#diff-948c1a730308e64455f74a88988fb0a98d894d1067cfcb229a2376c523835675L98-R89) [[2]](diffhunk://#diff-a23f45ae32e4e8e24c3e72f7a73039217e95938f6001a2ebe25e3d627b2be84eL74-R77)

Simplification and cleanup:

* Removed the error display and reload button logic from the `Communities` component, simplifying its UI and state management.
* Eliminated the `reloadToken` state and related effect dependencies from `Communities`, now only depending on the translation function for updates. [[1]](diffhunk://#diff-948c1a730308e64455f74a88988fb0a98d894d1067cfcb229a2376c523835675R6-L12) [[2]](diffhunk://#diff-948c1a730308e64455f74a88988fb0a98d894d1067cfcb229a2376c523835675L30-R30)